### PR TITLE
fix: restore PATH/PATHEXT after spreading the provider environment

### DIFF
--- a/src/local-agent-config.test.ts
+++ b/src/local-agent-config.test.ts
@@ -61,6 +61,19 @@ assert.deepEqual(inherited, {
   OPENAI_API_KEY: "inherited",
   UNCHANGED: "yes",
 });
+{
+  // Windows environment blocks commonly store "Path"; a spread drops the
+  // case-insensitive process.env.PATH lookup that command resolution relies on.
+  const windowsInherited = { Path: "C:\\tools;C:\\Windows", Other: "kept" };
+  const providerEnv = localAgentProviderEnvironment(
+    subagentsConfigSchema.parse({ enabled: true, providers: [{ id: "codex", enabled: true }] }),
+    "codex",
+    windowsInherited,
+  );
+  assert.equal(providerEnv.PATH, "C:\\tools;C:\\Windows");
+  assert.equal(providerEnv.Path, "C:\\tools;C:\\Windows");
+  assert.equal(providerEnv.Other, "kept");
+}
 assert.equal(
   localAgentProviderConfigRevision(config),
   localAgentProviderConfigRevision(subagentsConfigSchema.parse({

--- a/src/local-agent-config.ts
+++ b/src/local-agent-config.ts
@@ -82,10 +82,22 @@ export function localAgentProviderEnvironment(
 ): NodeJS.ProcessEnv {
   const providerConfig = subagentProviderConfig(config, provider);
   const env = { ...inherited, ...providerConfig?.env };
+  // process.env lookups are case-insensitive on Windows, but spreading copies
+  // only the original key casing (commonly "Path"); consumers reading the
+  // plain object's env.PATH then miss. Restore the canonical keys.
+  const pathValue = environmentValueCaseInsensitive(inherited, "PATH");
+  if (env.PATH === undefined && pathValue !== undefined) env.PATH = pathValue;
+  const pathExtValue = environmentValueCaseInsensitive(inherited, "PATHEXT");
+  if (env.PATHEXT === undefined && pathExtValue !== undefined) env.PATHEXT = pathExtValue;
   const commandVariable = providerCommandVariable(provider);
   const command = providerConfig && "command" in providerConfig ? providerConfig.command : undefined;
   if (commandVariable && command) env[commandVariable] = command;
   return env;
+}
+
+function environmentValueCaseInsensitive(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const found = Object.keys(env).find((entry) => entry.toUpperCase() === key);
+  return found === undefined ? undefined : env[found];
 }
 
 export function localAgentProviderEnvironmentOverrides(


### PR DESCRIPTION
Windows stores the search path in the environment block as mixed-case `Path`. `process.env.PATH` resolves case-insensitively, but `localAgentProviderEnvironment` builds each provider's env with a spread, which copies only the original key casing. Every consumer that later reads `env.PATH` from that plain object gets `undefined`: the availability walk reports codex/grok as "executable not found" on the startup banner, and the Codex driver's `resolveCodexCommand` fails before inference with `PROVIDER_UNAVAILABLE: Codex executable was not found.` — while the same probe succeeds from any shell that exports an uppercase `PATH` (e.g. Git Bash), so it only bites standard Windows service environments such as a cmd-launched MCP server.

The fix restores the canonical `PATH` and `PATHEXT` keys after the spread, sourcing values from any casing present in the inherited env and never overwriting an existing key. A regression test covers a `Path`-only inherited env, and I verified end-to-end in a child process whose environment block contains only `Path` that provider driver resolution now finds the codex executable (it returned undefined before).